### PR TITLE
Update dependency map so to work with referee >= 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "formatio": "~1.0"
   },
   "peerDependencies": {
-    "referee": ">= 1.10.0 < 2",
+    "referee": ">= 0.11.1 < 2",
     "referee-sinon": ">= 1.0.0 < 2",
     "sinon": ">= 1.6.0 < 2"
   },


### PR DESCRIPTION
referee v1.10.0 has changed the way how referee.js includes expect.js. 
Therefore, the dependency map in karma-referee has to be changed.
