### PR TITLE
Lock-down sinon version to 1.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   "peerDependencies": {
     "referee": ">= 1.1.0 < 2",
     "referee-sinon": ">= 1.0.0 < 2",
-    "sinon": ">= 1.6.0 < 2"
+    "sinon": "1.14.1"
   },
   "devDependencies": {
     "mocha": "^2.0.*",
     "referee": ">= 0.11.1 < 2",
     "referee-sinon": ">= 1.0.0 < 2",
-    "sinon": ">= 1.6.0 < 2"
+    "sinon": "1.14.1"
   }
 }


### PR DESCRIPTION
-- Lock-down sinon version to 1.14.1 until https://github.com/cjohansen/Sinon.JS/issues/761 is fixed
